### PR TITLE
fix a small bug in HRDetect.R when using Indels_tab_files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,5 +35,6 @@ Imports:
     scales,
     GenomicRanges,
     IRanges,
-    BSgenome
+    BSgenome,
+    readr
 RoxygenNote: 6.1.1

--- a/R/HRDetect.R
+++ b/R/HRDetect.R
@@ -444,7 +444,7 @@ HRDetect_pipeline <- function(data_matrix=NULL,
       message("[info HRDetect_pipeline] Proportion of Indels with MH will be computed for the following TAB samples: ",paste(incomplete_samples_with_tabIndels,collapse = " "))
       
       mh_list <- foreach::foreach(sample=incomplete_samples_with_tabIndels) %dopar% {
-        res <- tabToIndelsClassification(readr::read_tsv(Indels_vcf_files[sample]),sample,genome.v = genome.v)
+        res <- tabToIndelsClassification(readr::read_tsv(Indels_tab_files[sample]),sample,genome.v = genome.v)
         res$count_proportion
       }
       #combine in one table and add to data_matrix

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ This is the full list of R package dependencies:
     scales,
     GenomicRanges,
     IRanges,
-    BSgenome
+    BSgenome, 
+    readr
 ```
 
 <a name="test"/>


### PR DESCRIPTION
When running `HRDetect_pipeline` function using tab indel files, the function still tried to use `Indels_vcf_files` to identify the indel files. With this fix, it correctly choose from the `Indels_tab_files`.